### PR TITLE
Fixed config parameter name in example configuration file.

### DIFF
--- a/config/mocap.yaml
+++ b/config/mocap.yaml
@@ -1,4 +1,4 @@
-# 
+#
 # Definition of all trackable objects
 # Identifier corresponds to Trackable ID set in Tracking Tools
 #
@@ -11,5 +11,5 @@ rigid_bodies:
     '2':
         pose: Robot_2/pose
         pose2d: Robot_2/ground_pose
-        frame_id: Robot_2/base_link
+        child_frame_id: Robot_2/base_link
         parent_frame_id: world


### PR DESCRIPTION
frame_id -> child_frame_id: The latter is used in mocap_config.cpp (CHILD_FRAME_ID_PARAM_NAME)