### PR TITLE
Optitrack multicast address is now a parameter in the config file.

### DIFF
--- a/config/mocap.yaml
+++ b/config/mocap.yaml
@@ -13,3 +13,5 @@ rigid_bodies:
         pose2d: Robot_2/ground_pose
         child_frame_id: Robot_2/base_link
         parent_frame_id: world
+optitrack_config:
+        multicast_address: 224.0.0.1

--- a/config/mocap.yaml
+++ b/config/mocap.yaml
@@ -1,4 +1,4 @@
-# 
+#
 # Definition of all trackable objects
 # Identifier corresponds to Trackable ID set in Tracking Tools
 #
@@ -11,5 +11,5 @@ rigid_bodies:
     '2':
         pose: Robot_2/pose
         pose2d: Robot_2/ground_pose
-        frame_id: Robot_2/base_link
+        child_frame_id: Robot_2/base_link
         parent_frame_id: world


### PR DESCRIPTION
I accidentally branched off #14, sorry about that. If/when you accept that PR the diff should be fine.

This PR adds the multicast address in the config file, so one doesn't have to change the code directly to change the IP address. If no address is configured, the same address is used by default.

