### PR TITLE
Natnet and server version can now be set in config file

### DIFF
--- a/include/mocap_optitrack/mocap_config.h
+++ b/include/mocap_optitrack/mocap_config.h
@@ -52,6 +52,7 @@ struct ServerDescription
   int commandPort;
   int dataPort;
   std::string multicastIpAddress;
+  std::vector<int> version;
 };
 
 /// \brief ROS publisher configuration

--- a/src/mocap_config.cpp
+++ b/src/mocap_config.cpp
@@ -74,6 +74,7 @@ namespace rosparam
     const std::string MulticastIpAddress = "optitrack_config/multicast_address";
     const std::string CommandPort = "optitrack_config/command_port";
     const std::string DataPort = "optitrack_config/data_port";
+    const std::string Version = "optitrack_config/version";
     const std::string RigidBodies = "rigid_bodies";
     const std::string PoseTopicName = "pose";
     const std::string Pose2dTopicName = "pose2d";
@@ -122,6 +123,15 @@ void NodeConfiguration::fromRosParam(
   {
     ROS_WARN_STREAM("Could not get data port, using default: " << 
       serverDescription.dataPort);
+  }
+
+  if (nh.hasParam(rosparam::keys::Version) )
+  {
+    nh.getParam(rosparam::keys::Version, serverDescription.version);
+  }
+  else
+  {
+    ROS_WARN_STREAM("Could not get server version, using auto");
   }
 
   // Parse rigid bodies section

--- a/src/mocap_node.cpp
+++ b/src/mocap_node.cpp
@@ -61,6 +61,11 @@ namespace mocap_optitrack
         new UdpMulticastSocket(serverDescription.dataPort, 
           serverDescription.multicastIpAddress)); 
 
+      if (!serverDescription.version.empty())
+      {
+        dataModel.setVersions(&serverDescription.version[0], &serverDescription.version[0]);
+      }
+
       // Need verion information from the server to properly decode any of their packets.
       // If we have not recieved that yet, send another request.  
       while(ros::ok() && !dataModel.hasServerInfo())


### PR DESCRIPTION
Added a way to set both natnet and server version from yaml file, so you don't have to restart the broadcast from motive each time you launch the mocap node. Used by adding "version: [3,0,0,0]" (with whichever natnet version you are running) in the optitrack_config-part of the config file