### PR TITLE
Change in coordinate systems for Motive 2.1.1

### DIFF
--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -81,7 +81,6 @@ RigidBodyPublisher::RigidBodyPublisher(ros::NodeHandle &nh,
 
   // Motive 1.7+ uses a new coordinate system
   useNewCoordinates = (natNetVersion >= Version("1.7"));
-  ROS_INFO_STREAM("Using new coordinates = " << useNewCoordinates);
 }
 
 RigidBodyPublisher::~RigidBodyPublisher()

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -43,13 +43,13 @@ namespace utilities
     if (newCoordinates)
     {
       // Motive 1.7+ coordinate system
-      poseStampedMsg.pose.position.x = -body.pose.position.x;
+      poseStampedMsg.pose.position.x = body.pose.position.x;
       poseStampedMsg.pose.position.y = body.pose.position.z;
-      poseStampedMsg.pose.position.z = body.pose.position.y;
+      poseStampedMsg.pose.position.z = -body.pose.position.y;
   
-      poseStampedMsg.pose.orientation.x = -body.pose.orientation.x;
+      poseStampedMsg.pose.orientation.x = body.pose.orientation.x;
       poseStampedMsg.pose.orientation.y = body.pose.orientation.z;
-      poseStampedMsg.pose.orientation.z = body.pose.orientation.y;
+      poseStampedMsg.pose.orientation.z = -body.pose.orientation.y;
       poseStampedMsg.pose.orientation.w = body.pose.orientation.w;
     }
     else
@@ -81,6 +81,7 @@ RigidBodyPublisher::RigidBodyPublisher(ros::NodeHandle &nh,
 
   // Motive 1.7+ uses a new coordinate system
   useNewCoordinates = (natNetVersion >= Version("1.7"));
+  ROS_INFO_STREAM("Using new coordinates = " << useNewCoordinates);
 }
 
 RigidBodyPublisher::~RigidBodyPublisher()


### PR DESCRIPTION
These are the changes I had to make to line up the coordinate frames in Motive 2.1.1 and ROS Kinetic. I was visualizing the TFs in ROS using RViz. Optitrack was configured to stream with "Z up". I have the following `mocap.yaml`:
```
rigid_bodies:
    '1':
        pose: object/pose
        pose2d: object/ground_pose
        child_frame_id: object_frame
        parent_frame_id: optitrack_frame
optitrack_config:
        multicast_address: x.x.x.x
        command_port: 1510
        data_port: 1511
```