### PR TITLE
feat: dynamic reconfigure server parameters and enable optitrack parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,21 @@ endif()
 
 find_package(catkin REQUIRED COMPONENTS 
 	roscpp 
-	geometry_msgs 
+	geometry_msgs
+	dynamic_reconfigure 
 	tf 
 	roslaunch)
+
+# dynamic reconfigure
+generate_dynamic_reconfigure_options(
+  cfg/MocapOptitrack.cfg
+)
+
 
 catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS roscpp
+  dynamic_reconfigure
 )
 
 include_directories(include

--- a/cfg/MocapOptitrack.cfg
+++ b/cfg/MocapOptitrack.cfg
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+gen.add("enable_optitrack", bool_t, 1, "Switch node on/off", False)
+gen.add("command_port", int_t, 1, "Command port", 0, 0, 10000)
+gen.add("data_port", int_t, 1, "Data port", 0, 0, 10000)
+gen.add("multicast_address", str_t, 1, "Multicast IP address", '')
+
+
+
+
+exit(gen.generate("mocap_optitrack", "mocap_node", "MocapOptitrack"))

--- a/config/mocap.yaml
+++ b/config/mocap.yaml
@@ -17,3 +17,4 @@ optitrack_config:
         multicast_address: 224.0.0.1
         command_port: 1510
         data_port: 9000
+        enable_optitrack: true

--- a/include/mocap_optitrack/mocap_config.h
+++ b/include/mocap_optitrack/mocap_config.h
@@ -46,12 +46,14 @@ struct ServerDescription
     static const int CommandPort;
     static const int DataPort;
     static const std::string MulticastIpAddress;
+    static const bool EnableOptitrack;
   };
 
   ServerDescription();
   int commandPort;
   int dataPort;
   std::string multicastIpAddress;
+  bool enableOptitrack;
   std::vector<int> version;
 };
 

--- a/package.xml
+++ b/package.xml
@@ -35,4 +35,5 @@
   <depend>roscpp</depend>
   <depend>tf</depend>
   <depend>geometry_msgs</depend>
+  <depend>dynamic_reconfigure</depend>
 </package>

--- a/src/mocap_config.cpp
+++ b/src/mocap_config.cpp
@@ -65,6 +65,7 @@ namespace impl
 const int ServerDescription::Default::CommandPort = 1510;
 const int ServerDescription::Default::DataPort   = 9000;
 const std::string ServerDescription::Default::MulticastIpAddress = "224.0.0.1";
+const bool ServerDescription::Default::EnableOptitrack   = true;
 
 // Param keys
 namespace rosparam
@@ -74,6 +75,7 @@ namespace rosparam
     const std::string MulticastIpAddress = "optitrack_config/multicast_address";
     const std::string CommandPort = "optitrack_config/command_port";
     const std::string DataPort = "optitrack_config/data_port";
+    const std::string EnableOptitrack = "optitrack_config/enable_optitrack";
     const std::string Version = "optitrack_config/version";
     const std::string RigidBodies = "rigid_bodies";
     const std::string PoseTopicName = "pose";
@@ -86,6 +88,7 @@ namespace rosparam
 ServerDescription::ServerDescription() :
   commandPort(ServerDescription::Default::CommandPort),
   dataPort(ServerDescription::Default::DataPort),
+  enableOptitrack(ServerDescription::Default::EnableOptitrack),
   multicastIpAddress(ServerDescription::Default::MulticastIpAddress)
 {}
 
@@ -113,6 +116,16 @@ void NodeConfiguration::fromRosParam(
   {
     ROS_WARN_STREAM("Could not get command port, using default: " << 
       serverDescription.commandPort);
+  }
+
+  if (nh.hasParam(rosparam::keys::EnableOptitrack) )
+  {
+    nh.getParam(rosparam::keys::EnableOptitrack, serverDescription.enableOptitrack);
+  }
+  else
+  {
+    ROS_WARN_STREAM("Could not get enable optitrack, using default: " <<
+      serverDescription.enableOptitrack);
   }
 
   if (nh.hasParam(rosparam::keys::DataPort) )


### PR DESCRIPTION
This pull request has the following changes : 

- All server parameters become dynamic reconfigured parameters 
- A new parameter is add called `enable_optitrack`. This parameter will be useful for many applications when you need the node running on the device only during the experiment so you can switch it on/off when needed. 