### PR TITLE
fix: system coordinates with motive 2.2.0

### DIFF
--- a/include/mocap_optitrack/rigid_body_publisher.h
+++ b/include/mocap_optitrack/rigid_body_publisher.h
@@ -56,7 +56,7 @@ public:
 private:
   PublisherConfiguration config;
 
-  bool useNewCoordinates;
+  Version coordinatesVersion;
 
   tf::TransformBroadcaster tfPublisher;
   ros::Publisher posePublisher;

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -37,7 +37,7 @@ namespace mocap_optitrack
 
 namespace utilities
 {
-  geometry_msgs::PoseStamped getRosPose(RigidBody const& body, Version coordinatesVersion)
+  geometry_msgs::PoseStamped getRosPose(RigidBody const& body, const Version& coordinatesVersion)
   {
     geometry_msgs::PoseStamped poseStampedMsg;
     if (coordinatesVersion >= Version("2.0"))

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -37,16 +37,27 @@ namespace mocap_optitrack
 
 namespace utilities
 {
-  geometry_msgs::PoseStamped getRosPose(RigidBody const& body, bool newCoordinates)
+  geometry_msgs::PoseStamped getRosPose(RigidBody const& body, Version coordinatesVersion)
   {
     geometry_msgs::PoseStamped poseStampedMsg;
-    if (newCoordinates)
+    if (coordinatesVersion >= Version("2.0"))
     {
-      // Motive 1.7+ coordinate system
-      poseStampedMsg.pose.position.x = -body.pose.position.x;
+      // Motive 2.0+ coordinate system
+      poseStampedMsg.pose.position.x = body.pose.position.x;
       poseStampedMsg.pose.position.y = body.pose.position.z;
       poseStampedMsg.pose.position.z = body.pose.position.y;
   
+      poseStampedMsg.pose.orientation.x = body.pose.orientation.x;
+      poseStampedMsg.pose.orientation.y = body.pose.orientation.z;
+      poseStampedMsg.pose.orientation.z = body.pose.orientation.y;
+      poseStampedMsg.pose.orientation.w = body.pose.orientation.w;
+    }
+    else if (coordinatesVersion < Version("2.0") && coordinatesVersion >= Version("1.7")) {
+        // Motive 1.7+ coordinate system
+      poseStampedMsg.pose.position.x = -body.pose.position.x;
+      poseStampedMsg.pose.position.y = body.pose.position.z;
+      poseStampedMsg.pose.position.z = body.pose.position.y;
+
       poseStampedMsg.pose.orientation.x = -body.pose.orientation.x;
       poseStampedMsg.pose.orientation.y = body.pose.orientation.z;
       poseStampedMsg.pose.orientation.z = body.pose.orientation.y;
@@ -80,7 +91,9 @@ RigidBodyPublisher::RigidBodyPublisher(ros::NodeHandle &nh,
     pose2dPublisher = nh.advertise<geometry_msgs::Pose2D>(config.pose2dTopicName, 1000);
 
   // Motive 1.7+ uses a new coordinate system
-  useNewCoordinates = (natNetVersion >= Version("1.7"));
+//  natNetVersion = (natNetVersion >= Version("1.7"));
+    coordinatesVersion = natNetVersion ;
+
 }
 
 RigidBodyPublisher::~RigidBodyPublisher()
@@ -102,7 +115,7 @@ void RigidBodyPublisher::publish(ros::Time const& time, RigidBody const& body)
     return;
   }
 
-  geometry_msgs::PoseStamped pose = utilities::getRosPose(body, useNewCoordinates);
+  geometry_msgs::PoseStamped pose = utilities::getRosPose(body, coordinatesVersion);
   pose.header.stamp = time;
 
   if (config.publishPose)


### PR DESCRIPTION
In the latest Motive versions ( =>2.0.0) the coordinates system is changed. Now no need to add minus singes to the body pose coming from motive software because the coordinates match each other. 