### PR TITLE
Feat: add enable disable tf publisher param

### DIFF
--- a/config/mocap.yaml
+++ b/config/mocap.yaml
@@ -20,5 +20,5 @@ rigid_bodies:
 optitrack_config:
         multicast_address: 224.0.0.1
         command_port: 1510
-        data_port: 9000 
-        enable_optitrack: True
+        data_port: 9000
+        enable_optitrack: true

--- a/config/mocap.yaml
+++ b/config/mocap.yaml
@@ -7,12 +7,14 @@ rigid_bodies:
         pose: Robot_1/pose
         pose2d: Robot_1/ground_pose
         odom: Robot_1/Odom
+        tf: tf
         child_frame_id: Robot_1/base_link
         parent_frame_id: world
     '2':
         pose: Robot_2/pose
         pose2d: Robot_2/ground_pose
         odom: Robot_2/Odom
+        tf: tf
         child_frame_id: Robot_2/base_link
         parent_frame_id: world
 optitrack_config:

--- a/include/mocap_optitrack/mocap_config.h
+++ b/include/mocap_optitrack/mocap_config.h
@@ -66,6 +66,7 @@ struct PublisherConfiguration
   std::string odomTopicName;
   std::string childFrameId;
   std::string parentFrameId;
+  bool enableTfPublisher;
 
   bool publishPose;
   bool publishPose2d;

--- a/include/mocap_optitrack/mocap_config.h
+++ b/include/mocap_optitrack/mocap_config.h
@@ -64,9 +64,9 @@ struct PublisherConfiguration
   std::string poseTopicName;
   std::string pose2dTopicName;
   std::string odomTopicName;
+  std::string enableTfPublisher;
   std::string childFrameId;
   std::string parentFrameId;
-  bool enableTfPublisher;
 
   bool publishPose;
   bool publishPose2d;

--- a/src/mocap_config.cpp
+++ b/src/mocap_config.cpp
@@ -85,7 +85,6 @@ const std::string OdomTopicName = "odom";
 const std::string EnableTfPublisher = "tf";
 const std::string ChildFrameId = "child_frame_id";
 const std::string ParentFrameId = "parent_frame_id";
-
 }  // namespace keys
 }  // namespace rosparam
 
@@ -213,7 +212,6 @@ void NodeConfiguration::fromRosParam(
           {
             publisherConfig.publishOdom = true;
           }
-
 
           bool readEnableTfPublisher = impl::check_and_get_param(bodyParameters,
                                                                  rosparam::keys::EnableTfPublisher, publisherConfig.enableTfPublisher);

--- a/src/mocap_config.cpp
+++ b/src/mocap_config.cpp
@@ -82,7 +82,7 @@ const std::string RigidBodies = "rigid_bodies";
 const std::string PoseTopicName = "pose";
 const std::string Pose2dTopicName = "pose2d";
 const std::string OdomTopicName = "odom";
-const bool EnableTfPublisher = true;
+const std::string EnableTfPublisher = "enable_tf_publisher";
 const std::string ChildFrameId = "child_frame_id";
 const std::string ParentFrameId = "parent_frame_id";
 }  // namespace keys
@@ -213,15 +213,28 @@ void NodeConfiguration::fromRosParam(
             publisherConfig.publishOdom = true;
           }
 
+
+          bool readEnableTfPublisher = impl::check_and_get_param(bodyParameters,
+                                                                 rosparam::keys::EnableTfPublisher, publisherConfig.enableTfPublisher);
+          if (!readEnableTfPublisher)
+          {
+            ROS_WARN_STREAM("Failed to parse " << rosparam::keys::EnableTfPublisher <<
+                            " for body `" << publisherConfig.rigidBodyId << "`. Tf publisher is set default as true .");
+            publisherConfig.publishTf = true;
+          }
+          else
+          {
+            publisherConfig.publishTf = nh.getParam(rosparam::keys::EnableTfPublisher, publisherConfig.enableTfPublisher);
+          }
+
           bool readChildFrameId = impl::check_and_get_param(bodyParameters,
                                   rosparam::keys::ChildFrameId, publisherConfig.childFrameId);
 
           bool readParentFrameId = impl::check_and_get_param(bodyParameters,
                                    rosparam::keys::ParentFrameId, publisherConfig.parentFrameId);
 
-          bool readEnableTfPublisher = rosparam::keys::EnableTfPublisher;
 
-          if (!readChildFrameId || !readParentFrameId || !readEnableTfPublisher)
+          if (!readChildFrameId || !readParentFrameId || !publisherConfig.publishTf)
           { if (!readEnableTfPublisher)
                   ROS_WARN_STREAM("Enable Tf publisher is " << rosparam::keys::EnableTfPublisher <<
                                   " for body `" << publisherConfig.rigidBodyId << "`. TF publishing disabled.");

--- a/src/mocap_config.cpp
+++ b/src/mocap_config.cpp
@@ -82,6 +82,7 @@ const std::string RigidBodies = "rigid_bodies";
 const std::string PoseTopicName = "pose";
 const std::string Pose2dTopicName = "pose2d";
 const std::string OdomTopicName = "odom";
+const bool EnableTfPublisher = true;
 const std::string ChildFrameId = "child_frame_id";
 const std::string ParentFrameId = "parent_frame_id";
 }  // namespace keys
@@ -218,8 +219,12 @@ void NodeConfiguration::fromRosParam(
           bool readParentFrameId = impl::check_and_get_param(bodyParameters,
                                    rosparam::keys::ParentFrameId, publisherConfig.parentFrameId);
 
-          if (!readChildFrameId || !readParentFrameId)
-          {
+          bool readEnableTfPublisher = rosparam::keys::EnableTfPublisher;
+
+          if (!readChildFrameId || !readParentFrameId || !readEnableTfPublisher)
+          { if (!readEnableTfPublisher)
+                  ROS_WARN_STREAM("Enable Tf publisher is " << rosparam::keys::EnableTfPublisher <<
+                                  " for body `" << publisherConfig.rigidBodyId << "`. TF publishing disabled.");
             if (!readChildFrameId)
               ROS_WARN_STREAM("Failed to parse " << rosparam::keys::ChildFrameId <<
                               " for body `" << publisherConfig.rigidBodyId << "`. TF publishing disabled.");

--- a/src/mocap_config.cpp
+++ b/src/mocap_config.cpp
@@ -82,9 +82,10 @@ const std::string RigidBodies = "rigid_bodies";
 const std::string PoseTopicName = "pose";
 const std::string Pose2dTopicName = "pose2d";
 const std::string OdomTopicName = "odom";
-const std::string EnableTfPublisher = "enable_tf_publisher";
+const std::string EnableTfPublisher = "tf";
 const std::string ChildFrameId = "child_frame_id";
 const std::string ParentFrameId = "parent_frame_id";
+
 }  // namespace keys
 }  // namespace rosparam
 
@@ -218,13 +219,15 @@ void NodeConfiguration::fromRosParam(
                                                                  rosparam::keys::EnableTfPublisher, publisherConfig.enableTfPublisher);
           if (!readEnableTfPublisher)
           {
-            ROS_WARN_STREAM("Failed to parse " << rosparam::keys::EnableTfPublisher <<
-                            " for body `" << publisherConfig.rigidBodyId << "`. Tf publisher is set default as true .");
-            publisherConfig.publishTf = true;
+              ROS_WARN_STREAM("Failed to parse " << rosparam::keys::EnableTfPublisher <<
+                              " for body `" << publisherConfig.enableTfPublisher << "`. Tf publishing disabled.");
+            publisherConfig.publishTf = false;
           }
           else
           {
             publisherConfig.publishTf = nh.getParam(rosparam::keys::EnableTfPublisher, publisherConfig.enableTfPublisher);
+            publisherConfig.publishTf = true;
+
           }
 
           bool readChildFrameId = impl::check_and_get_param(bodyParameters,
@@ -233,10 +236,9 @@ void NodeConfiguration::fromRosParam(
           bool readParentFrameId = impl::check_and_get_param(bodyParameters,
                                    rosparam::keys::ParentFrameId, publisherConfig.parentFrameId);
 
-
           if (!readChildFrameId || !readParentFrameId || !publisherConfig.publishTf)
           { if (!readEnableTfPublisher)
-                  ROS_WARN_STREAM("Enable Tf publisher is " << rosparam::keys::EnableTfPublisher <<
+                  ROS_WARN_STREAM("tf is not found in the config" << rosparam::keys::EnableTfPublisher <<
                                   " for body `" << publisherConfig.rigidBodyId << "`. TF publishing disabled.");
             if (!readChildFrameId)
               ROS_WARN_STREAM("Failed to parse " << rosparam::keys::ChildFrameId <<

--- a/src/mocap_config.cpp
+++ b/src/mocap_config.cpp
@@ -214,7 +214,7 @@ void NodeConfiguration::fromRosParam(
           }
 
           bool readEnableTfPublisher = impl::check_and_get_param(bodyParameters,
-                                                                 rosparam::keys::EnableTfPublisher, publisherConfig.enableTfPublisher);
+                               rosparam::keys::EnableTfPublisher, publisherConfig.enableTfPublisher);
           if (!readEnableTfPublisher)
           {
               ROS_WARN_STREAM("Failed to parse " << rosparam::keys::EnableTfPublisher <<


### PR DESCRIPTION
Publishing tf messages is not always handy. While testing with our robot publishing tf messages causes conflict in our localization system since the child parents frame ids are the same so I added tf topic as a param to enable/disable it like other topics. Knowing that removing the child and the parents frame ID's would disable the tf publisher but these frames are also used for publishing poses and odom messages so they cannot be removed in this case. 