### PR TITLE
Fix/coordinate system motive 2.0

### DIFF
--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -42,22 +42,9 @@ namespace utilities
 geometry_msgs::PoseStamped getRosPose(RigidBody const& body, const Version& coordinatesVersion)
 {
   geometry_msgs::PoseStamped poseStampedMsg;
-  if (coordinatesVersion >= Version("2.0"))
+  if (coordinatesVersion < Version("2.0") && coordinatesVersion >= Version("1.7"))
   {
-    // Motive 2.0+ coordinate system
-    // Motive 2.0+ in the settings of streaming `UP Axis` should be set to `Z Up` to match ROS coordinate system
-    poseStampedMsg.pose.position.x = body.pose.position.x;
-    poseStampedMsg.pose.position.y = body.pose.position.y;
-    poseStampedMsg.pose.position.z = body.pose.position.z;
-
-    poseStampedMsg.pose.orientation.x = body.pose.orientation.x;
-    poseStampedMsg.pose.orientation.y = body.pose.orientation.y;
-    poseStampedMsg.pose.orientation.z = body.pose.orientation.z;
-    poseStampedMsg.pose.orientation.w = body.pose.orientation.w;
-  }
-  else if (coordinatesVersion < Version("2.0") && coordinatesVersion >= Version("1.7"))
-  {
-    // Motive 1.7+ coordinate system
+    // Motive 1.7+ and < Motive 2.0 coordinate system
     poseStampedMsg.pose.position.x = -body.pose.position.x;
     poseStampedMsg.pose.position.y = body.pose.position.z;
     poseStampedMsg.pose.position.z = body.pose.position.y;
@@ -70,6 +57,7 @@ geometry_msgs::PoseStamped getRosPose(RigidBody const& body, const Version& coor
   else
   {
     // y & z axes are swapped in the Optitrack coordinate system
+    // Also compatible with versions > Motive 2.0
     poseStampedMsg.pose.position.x = body.pose.position.x;
     poseStampedMsg.pose.position.y = -body.pose.position.z;
     poseStampedMsg.pose.position.z = body.pose.position.y;
@@ -84,22 +72,9 @@ geometry_msgs::PoseStamped getRosPose(RigidBody const& body, const Version& coor
 nav_msgs::Odometry getRosOdom(RigidBody const& body, const Version& coordinatesVersion)
 {
   nav_msgs::Odometry OdometryMsg;
-  if (coordinatesVersion >= Version("2.0"))
+  if (coordinatesVersion < Version("2.0") && coordinatesVersion >= Version("1.7"))
   {
-    // Motive 2.0+ coordinate system
-    // Motive 2.0+ in the settings of streaming `UP Axis` should be set to `Z Up` to match ROS coordinate system
-    OdometryMsg.pose.pose.position.x = body.pose.position.x;
-    OdometryMsg.pose.pose.position.y = body.pose.position.y;
-    OdometryMsg.pose.pose.position.z = body.pose.position.z;
-
-    OdometryMsg.pose.pose.orientation.x = body.pose.orientation.x;
-    OdometryMsg.pose.pose.orientation.y = body.pose.orientation.y;
-    OdometryMsg.pose.pose.orientation.z = body.pose.orientation.z;
-    OdometryMsg.pose.pose.orientation.w = body.pose.orientation.w;
-  }
-  else if (coordinatesVersion < Version("2.0") && coordinatesVersion >= Version("1.7"))
-  {
-    // Motive 1.7+ coordinate system
+    // Motive 1.7+ and < Motive 2.0 coordinate system
     OdometryMsg.pose.pose.position.x = -body.pose.position.x;
     OdometryMsg.pose.pose.position.y = body.pose.position.z;
     OdometryMsg.pose.pose.position.z = body.pose.position.y;
@@ -112,6 +87,7 @@ nav_msgs::Odometry getRosOdom(RigidBody const& body, const Version& coordinatesV
   else
   {
     // y & z axes are swapped in the Optitrack coordinate system
+    // Also compatible with versions > Motive 2.0
     OdometryMsg.pose.pose.position.x = body.pose.position.x;
     OdometryMsg.pose.pose.position.y = -body.pose.position.z;
     OdometryMsg.pose.pose.position.z = body.pose.position.y;

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -45,13 +45,14 @@ geometry_msgs::PoseStamped getRosPose(RigidBody const& body, const Version& coor
   if (coordinatesVersion >= Version("2.0"))
   {
     // Motive 2.0+ coordinate system
+    // Motive 2.0+ in the settings of streaming UP Axix should be set to Z Up to match ROS coordinate system
     poseStampedMsg.pose.position.x = body.pose.position.x;
-    poseStampedMsg.pose.position.y = body.pose.position.z;
-    poseStampedMsg.pose.position.z = body.pose.position.y;
+    poseStampedMsg.pose.position.y = body.pose.position.y;
+    poseStampedMsg.pose.position.z = body.pose.position.z;
 
     poseStampedMsg.pose.orientation.x = body.pose.orientation.x;
-    poseStampedMsg.pose.orientation.y = body.pose.orientation.z;
-    poseStampedMsg.pose.orientation.z = body.pose.orientation.y;
+    poseStampedMsg.pose.orientation.y = body.pose.orientation.y;
+    poseStampedMsg.pose.orientation.z = body.pose.orientation.z;
     poseStampedMsg.pose.orientation.w = body.pose.orientation.w;
   }
   else if (coordinatesVersion < Version("2.0") && coordinatesVersion >= Version("1.7"))
@@ -86,13 +87,14 @@ nav_msgs::Odometry getRosOdom(RigidBody const& body, const Version& coordinatesV
   if (coordinatesVersion >= Version("2.0"))
   {
     // Motive 2.0+ coordinate system
+    // Motive 2.0+ in the settings of streaming `UP Axis` should be set to `Z Up` to match ROS coordinate system
     OdometryMsg.pose.pose.position.x = body.pose.position.x;
-    OdometryMsg.pose.pose.position.y = body.pose.position.z;
-    OdometryMsg.pose.pose.position.z = body.pose.position.y;
+    OdometryMsg.pose.pose.position.y = body.pose.position.y;
+    OdometryMsg.pose.pose.position.z = body.pose.position.z;
 
     OdometryMsg.pose.pose.orientation.x = body.pose.orientation.x;
-    OdometryMsg.pose.pose.orientation.y = body.pose.orientation.z;
-    OdometryMsg.pose.pose.orientation.z = body.pose.orientation.y;
+    OdometryMsg.pose.pose.orientation.y = body.pose.orientation.y;
+    OdometryMsg.pose.pose.orientation.z = body.pose.orientation.z;
     OdometryMsg.pose.pose.orientation.w = body.pose.orientation.w;
   }
   else if (coordinatesVersion < Version("2.0") && coordinatesVersion >= Version("1.7"))

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -45,7 +45,7 @@ geometry_msgs::PoseStamped getRosPose(RigidBody const& body, const Version& coor
   if (coordinatesVersion >= Version("2.0"))
   {
     // Motive 2.0+ coordinate system
-    // Motive 2.0+ in the settings of streaming UP Axix should be set to Z Up to match ROS coordinate system
+    // Motive 2.0+ in the settings of streaming `UP Axis` should be set to `Z Up` to match ROS coordinate system
     poseStampedMsg.pose.position.x = body.pose.position.x;
     poseStampedMsg.pose.position.y = body.pose.position.y;
     poseStampedMsg.pose.position.z = body.pose.position.z;


### PR DESCRIPTION
After testing the system on our robot and after visualizing the results on the RVIZ. It appeared that the coordinate system is used by Motive 2.0+ is using the right hand Y up coordinate system. However ROS uses also right hand but Z up coordinate system. The way that was implemented in the package is totally wrong switching the values of the axis Y and Z is not a solution. But introducing a rotation between the axis is. Luckily Motive 2.0+ supports publishing messages with Z up. This could be found in 
streaming -> UP Axis 
After setting the UP axis to Z Up. No need to do any thing in the odom/poses messages just stream the data as it is.