### PR TITLE
Fix/infinit fast reconnect loop

### DIFF
--- a/src/mocap_node.cpp
+++ b/src/mocap_node.cpp
@@ -131,6 +131,7 @@ public:
         }
       }
       ros::spinOnce();
+      ros::Duration(1.).sleep();
     }
   }
 

--- a/src/mocap_node.cpp
+++ b/src/mocap_node.cpp
@@ -129,7 +129,8 @@ public:
           // If we processed some data, take a short break
           usleep(10);
         }
-      }else {ros::Duration(1.).sleep();}
+      }
+      else {ros::Duration(1.).sleep();}
       ros::spinOnce();
     }
   }

--- a/src/mocap_node.cpp
+++ b/src/mocap_node.cpp
@@ -129,9 +129,8 @@ public:
           // If we processed some data, take a short break
           usleep(10);
         }
-      }
+      }else {ros::Duration(1.).sleep();}
       ros::spinOnce();
-      ros::Duration(1.).sleep();
     }
   }
 

--- a/src/mocap_node.cpp
+++ b/src/mocap_node.cpp
@@ -130,7 +130,10 @@ public:
           usleep(10);
         }
       }
-      else {ros::Duration(1.).sleep();}
+      else
+      {
+        ros::Duration(1.).sleep();
+      }
       ros::spinOnce();
     }
   }


### PR DESCRIPTION
This bug has found while testing ! if the node is in disable mode .. it tries in a fast infinit loop which consumes alot of power for nothing.