### PR TITLE
Correct timestamps

### DIFF
--- a/include/mocap_optitrack/data_model.h
+++ b/include/mocap_optitrack/data_model.h
@@ -70,6 +70,7 @@ struct RigidBody
     Pose pose;
     float meanMarkerError;
     bool isTrackingValid;
+    double trackTimestamp;
 
     bool hasValidData() const;
 };

--- a/include/mocap_optitrack/rigid_body_publisher.h
+++ b/include/mocap_optitrack/rigid_body_publisher.h
@@ -56,12 +56,14 @@ public:
     Version const& natNetVersion, 
     PublisherConfiguration const& config);
   ~RigidBodyPublisher();
-  void publish(rclcpp::Time const& time, RigidBody const&);
+  void publish(rclcpp::Time const& time, RigidBody const&, rclcpp::Logger);
 
 private:
   PublisherConfiguration config;
 
   bool useNewCoordinates;
+
+  double timeDifference;	//For syncing optitrack clock to ROS clock
 
   tf2_ros::TransformBroadcaster tfPublisher;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr posePublisher;
@@ -79,7 +81,7 @@ public:
     RigidBodyPublishDispatcher(rclcpp::Node::SharedPtr &node, 
         Version const& natNetVersion, 
         PublisherConfigurations const& configs);
-    void publish(rclcpp::Time const& time, std::vector<RigidBody> const& rigidBodies);
+    void publish(rclcpp::Time const& time, std::vector<RigidBody> const& rigidBodies, rclcpp::Logger logger);
 };
 
 } // namespace

--- a/src/mocap_node.cpp
+++ b/src/mocap_node.cpp
@@ -105,7 +105,7 @@ namespace mocap_optitrack
           // Maybe we got some data? If we did it would be in the form of one or more
           // rigid bodies in the data model
           const rclcpp::Time time = clock->now();
-          publishDispatcherPtr->publish(time, dataModel.dataFrame.rigidBodies);
+          publishDispatcherPtr->publish(time, dataModel.dataFrame.rigidBodies, node->get_logger());
 
           // Clear out the model to prepare for the next frame of data
           dataModel.clear();

--- a/src/natnet/natnet_messages.cpp
+++ b/src/natnet/natnet_messages.cpp
@@ -455,6 +455,12 @@ void DataFrameMessage::deserialize(
   }
   RCLCPP_DEBUG(logger, "Timestamp: %3.3f", timestamp);
 
+  // Loop over rigid bodies to add optitrack timestamp
+  for (auto& rigidBody : dataFrame->rigidBodies)
+  {
+    rigidBody.trackTimestamp = timestamp;
+  }
+
   // high res timestamps (version 3.0 and later)
   if (NatNetVersion >= mocap_optitrack::Version("3.0"))
   {


### PR DESCRIPTION
I changed the node to take the timestamp from the OptiTrack system instead of the timestamp at which the pose was received in ROS.

### Performance with these changes
- The offset between the optitrack clock and ros clock is estimated.
- Time accuracy is less than the lowest ping since the program is running.
- Time between timestamps is now correct.

### Performance before these changes
- Optitrack clock is not used.
- Time accuracy is dependend on current ping.
- Time between timestamps may fluctuate dramatically depending on network speed.