### PR TITLE
Humble support and removal of undesired transformation between y and z axis

### DIFF
--- a/include/mocap_optitrack/mocap_config.h
+++ b/include/mocap_optitrack/mocap_config.h
@@ -54,6 +54,10 @@ namespace rosparam
     const std::string EnableTfPublisher = "tf";
     const std::string ChildFrameId = "child_frame_id";
     const std::string ParentFrameId = "parent_frame_id";
+    const std::string QosOverrideDurability = "qos_overrides./tf.publisher.durability";
+    const std::string QosOverrideHistory = "qos_overrides./tf.publisher.history";
+    const std::string QosOverrideDepth = "qos_overrides./tf.publisher.depth";
+    const std::string QosOverrideReliability = "qos_overrides./tf.publisher.reliability";
   }
 }
 
@@ -66,6 +70,10 @@ struct ServerDescription
     static const int DataPort;
     static const std::string MulticastIpAddress;
     static const bool EnableOptitrack;
+    static const std::string QosOverrideDurability;
+    static const std::string QosOverrideHistory;
+    static const int QosOverrideDepth;
+    static const std::string QosOverrideReliability;
   };
 
   ServerDescription();
@@ -74,6 +82,10 @@ struct ServerDescription
   std::string multicastIpAddress;
   bool enableOptitrack;
   std::vector<int64_t> version;
+  std::string QosOverrideDurability;
+  std::string QosOverrideHistory;
+  int QosOverrideDepth;
+  std::string QosOverrideReliability;
 };
 
 /// \brief ROS publisher configuration

--- a/src/mocap_node.cpp
+++ b/src/mocap_node.cpp
@@ -163,7 +163,6 @@ namespace mocap_optitrack
         RCLCPP_INFO(node->get_logger(), "Got parameter: '%s'", ss.str().c_str());
 
         std::string rigid_bodies_prefix = "rigid_bodies.";
-
         if (!param.get_name().compare(rosparam::keys::CommandPort))
         {
           serverDescription.commandPort = param.as_int();
@@ -179,6 +178,23 @@ namespace mocap_optitrack
         else if (!param.get_name().compare(rosparam::keys::EnableOptitrack))
         {
           serverDescription.enableOptitrack = param.as_bool();
+        }
+        //In ROS humble qos is added as parameter, these lines add this to catch the exception, but overriding QOS is not implemented
+        else if (!param.get_name().compare(rosparam::keys::QosOverrideDurability))
+        {
+          serverDescription.QosOverrideDurability = param.as_string();
+        }
+        else if (!param.get_name().compare(rosparam::keys::QosOverrideHistory))
+        {
+          serverDescription.QosOverrideHistory = param.as_string();
+        }
+        else if (!param.get_name().compare(rosparam::keys::QosOverrideDepth))
+        {
+          serverDescription.QosOverrideDepth = param.as_int();
+        }
+        else if (!param.get_name().compare(rosparam::keys::QosOverrideReliability))
+        {
+          serverDescription.QosOverrideReliability = param.as_string();
         }
         else
         {

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -46,12 +46,12 @@ namespace utilities
     {
       // Motive 1.7+ and < Motive 2.0 coordinate system
       poseStampedMsg.pose.position.x = -body.pose.position.x;
-      poseStampedMsg.pose.position.y = body.pose.position.z;
-      poseStampedMsg.pose.position.z = body.pose.position.y;
+      poseStampedMsg.pose.position.y = body.pose.position.y;
+      poseStampedMsg.pose.position.z = body.pose.position.z;
 
       poseStampedMsg.pose.orientation.x = -body.pose.orientation.x;
-      poseStampedMsg.pose.orientation.y = body.pose.orientation.z;
-      poseStampedMsg.pose.orientation.z = body.pose.orientation.y;
+      poseStampedMsg.pose.orientation.y = body.pose.orientation.y;
+      poseStampedMsg.pose.orientation.z = body.pose.orientation.z;
       poseStampedMsg.pose.orientation.w = body.pose.orientation.w;
     }
     else
@@ -59,12 +59,12 @@ namespace utilities
       // y & z axes are swapped in the Optitrack coordinate system
       // Also compatible with versions > Motive 2.0
       poseStampedMsg.pose.position.x = body.pose.position.x;
-      poseStampedMsg.pose.position.y = -body.pose.position.z;
-      poseStampedMsg.pose.position.z = body.pose.position.y;
+      poseStampedMsg.pose.position.y = -body.pose.position.y;
+      poseStampedMsg.pose.position.z = body.pose.position.z;
 
       poseStampedMsg.pose.orientation.x = body.pose.orientation.x;
-      poseStampedMsg.pose.orientation.y = -body.pose.orientation.z;
-      poseStampedMsg.pose.orientation.z = body.pose.orientation.y;
+      poseStampedMsg.pose.orientation.y = -body.pose.orientation.y;
+      poseStampedMsg.pose.orientation.z = body.pose.orientation.z;
       poseStampedMsg.pose.orientation.w = body.pose.orientation.w;
     }
     return poseStampedMsg;
@@ -77,12 +77,12 @@ nav_msgs::msg::Odometry getRosOdom(RigidBody const& body, const Version& coordin
     {
       // Motive 1.7+ and < Motive 2.0 coordinate system
       OdometryMsg.pose.pose.position.x = -body.pose.position.x;
-      OdometryMsg.pose.pose.position.y = body.pose.position.z;
-      OdometryMsg.pose.pose.position.z = body.pose.position.y;
+      OdometryMsg.pose.pose.position.y = body.pose.position.y;
+      OdometryMsg.pose.pose.position.z = body.pose.position.z;
 
       OdometryMsg.pose.pose.orientation.x = -body.pose.orientation.x;
-      OdometryMsg.pose.pose.orientation.y = body.pose.orientation.z;
-      OdometryMsg.pose.pose.orientation.z = body.pose.orientation.y;
+      OdometryMsg.pose.pose.orientation.y = body.pose.orientation.y;
+      OdometryMsg.pose.pose.orientation.z = body.pose.orientation.z;
       OdometryMsg.pose.pose.orientation.w = body.pose.orientation.w;
     }
     else
@@ -90,12 +90,12 @@ nav_msgs::msg::Odometry getRosOdom(RigidBody const& body, const Version& coordin
       // y & z axes are swapped in the Optitrack coordinate system
       // Also compatible with versions > Motive 2.0
       OdometryMsg.pose.pose.position.x = body.pose.position.x;
-      OdometryMsg.pose.pose.position.y = -body.pose.position.z;
-      OdometryMsg.pose.pose.position.z = body.pose.position.y;
+      OdometryMsg.pose.pose.position.y = -body.pose.position.y;
+      OdometryMsg.pose.pose.position.z = body.pose.position.z;
 
       OdometryMsg.pose.pose.orientation.x = body.pose.orientation.x;
-      OdometryMsg.pose.pose.orientation.y = -body.pose.orientation.z;
-      OdometryMsg.pose.pose.orientation.z = body.pose.orientation.y;
+      OdometryMsg.pose.pose.orientation.y = -body.pose.orientation.y;
+      OdometryMsg.pose.pose.orientation.z = body.pose.orientation.z;
       OdometryMsg.pose.pose.orientation.w = body.pose.orientation.w;
     }
     return OdometryMsg;


### PR DESCRIPTION
Qos got added in ROS humble as a default parameter. This is not caught during launch by the mocap node and causes the program to always crash in humble. I didnt implement QOS parameters but just added catch exceptions for possible further work. I also removed an unnecessary flip between y and z as already removed before by @321thijs123 but was re-added for no apparent reason in a later commit. 