### PR TITLE
make the optitrack enabled by default in cfg

### DIFF
--- a/cfg/MocapOptitrack.cfg
+++ b/cfg/MocapOptitrack.cfg
@@ -2,7 +2,7 @@
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("enable_optitrack", bool_t, 1, "Switch node on/off", False)
+gen.add("enable_optitrack", bool_t, 1, "Switch node on/off", True)
 gen.add("command_port", int_t, 1, "Command port", 0, 0, 10000)
 gen.add("data_port", int_t, 1, "Data port", 0, 0, 10000)
 gen.add("multicast_address", str_t, 1, "Multicast IP address", '')


### PR DESCRIPTION
If the enableOptitrack value is not explicitly set in the launch file, the package defaults to true, as specified in the [source code](https://github.com/ros-drivers/mocap_optitrack/blob/master/src/mocap_config.cpp#L69). However, if the roscore is kept running in another terminal without restarting, this setting only takes effect once. The solution is to set the default value to True in the configuration (cfg) file.

Below are some relevant log entries:

 For the first run, the enableOptitrack can be set to 1 by default.

    [ WARN] [1724039169.350641447]: Could not get enable optitrack, using default: 1
    [ WARN] [1724039169.352661334]: Could not get server version, using auto
    [ WARN] [1724039169.353305319]: Failed to parse odom for body 1. Odom publishing disabled.
    [ WARN] [1724039169.353321242]: Failed to parse tf for body ``. Tf publishing disabled.
    [ WARN] [1724039169.353328661]: tf is not found in the configtf for body 1. TF publishing disabled.
    [ERROR] [1724039169.356911610]: serverDescription.enableOptitrack: 0
    [ WARN] [1724039169.356936564]: enableOptitrack is False. Initialization is uncompleted.
    [ERROR] [1724039169.357799937]: serverDescription.enableOptitrack: 1
    [ WARN] [1724039170.358444244]: Client has not received server info request. Parsing data message aborted.
    [ WARN] [1724039170.361970986]: NATNet Version : 4.1.0.0
    [ WARN] [1724039170.361994939]: Server Version : 3.1.1.1
    [ WARN] [1724039170.364784255]: Initialization is completed.
    [ WARN] [1724039170.364800823]: Running...

However, for the second run, the enableOptitrack cannot be set to 1.

    [ WARN] [1724039177.062203546]: Could not get server version, using auto
    [ WARN] [1724039177.062884631]: Failed to parse odom for body 1. Odom publishing disabled.
    [ WARN] [1724039177.062895496]: Failed to parse tf for body ``. Tf publishing disabled.
    [ WARN] [1724039177.062905874]: tf is not found in the configtf for body 1. TF publishing disabled.
    [ERROR] [1724039177.065013813]: serverDescription.enableOptitrack: 0
    [ WARN] [1724039177.065023648]: enableOptitrack is False. Initialization is uncompleted.
    [ERROR] [1724039177.065863651]: serverDescription.enableOptitrack: 0
    [ WARN] [1724039177.065871082]: enableOptitrack is False. Initialization is uncompleted.
    [ WARN] [1724039177.065877737]: Running...
