### PR TITLE
Change compiler option to use C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,11 @@ project(mocap_optitrack)
 
 # Require c++11
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if(COMPILER_SUPPORTS_CXX11)
-    set(CMAKE_CXX_FLAGS "-std=c++11")
+CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+if(COMPILER_SUPPORTS_CXX17)
+    set(CMAKE_CXX_FLAGS "-std=c++17")
 else()
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
 endif()
 
 find_package(catkin REQUIRED COMPONENTS 


### PR DESCRIPTION
I am using ROS-O to run ROS1 on ubuntu22.04, and I have raised the compiler C++ version to C++17 to pass the build on ubuntu22.04. 